### PR TITLE
Run nginx backend on less common port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       SERVICE: flask
       FLASKR_SETTINGS: '../config.dev.cfg'
     ports:
-      - 127.0.0.1:5000:8080
+      - 127.0.0.1:5000:9764
     volumes:
       - ./src/karmen_backend/server:/usr/src/app/server
       - ./tmp/karmen-files:/tmp/karmen-files
@@ -70,6 +70,7 @@ services:
     environment:
       ENV: develop
       SERVICE: fake-printer
+      SERVICE_PORT: 8080
     networks:
       printers:
         ipv4_address: 172.16.236.11
@@ -79,6 +80,7 @@ services:
     environment:
       ENV: develop
       SERVICE: fake-printer
+      SERVICE_PORT: 8080
     networks:
       printers:
         ipv4_address: 172.16.236.12

--- a/src/karmen_backend/Dockerfile
+++ b/src/karmen_backend/Dockerfile
@@ -18,10 +18,11 @@ RUN pipenv lock --requirements > requirements.txt && pip install --no-cache-dir 
 
 ENV REDIS_HOST 127.0.0.1
 ENV REDIS_PORT 6379
+ENV SERVICE_PORT 9764
 
 COPY . .
 COPY ./scripts/nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
 
 CMD ["./scripts/docker-start.sh"]
 
-EXPOSE 8080
+EXPOSE ${SERVICE_PORT}

--- a/src/karmen_backend/scripts/docker-start.sh
+++ b/src/karmen_backend/scripts/docker-start.sh
@@ -30,7 +30,7 @@ if [ "$SERVICE" = 'flask' ]; then
   else
     export FLASK_APP=server
     export FLASK_DEBUG=true
-    flask run --host=0.0.0.0 --port 8080
+    flask run --host=0.0.0.0 --port 9764
   fi
 elif [ "$SERVICE" = 'celery-beat' ]; then
   test_flaskr_settings

--- a/src/karmen_backend/scripts/nginx.conf
+++ b/src/karmen_backend/scripts/nginx.conf
@@ -10,7 +10,7 @@ events {
     use epoll;
     multi_accept on;
 }
-  
+
 http {
   access_log /dev/stdout;
   error_log /dev/stdout;
@@ -25,8 +25,8 @@ http {
   client_max_body_size 256M;
 
   server {
-    listen       8080 default_server;
-    listen       [::]:8080 default_server;
+    listen       9764 default_server;
+    listen       [::]:9764 default_server;
     resolver     127.0.0.11 valid=5m;
     server_name  localhost;
 


### PR DESCRIPTION
This moves backend to run on 9764 port which should not conflict with some other stuff like OctoPrint mjpeg streamer.