### PR TITLE
Cuda remote

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ config.local.cfg
 tmp
 .travis/karmen
 .travis/*.zip
+.idea
+

--- a/src/karmen_backend/server/routes/octoprintemulator.py
+++ b/src/karmen_backend/server/routes/octoprintemulator.py
@@ -25,6 +25,80 @@ def version():
     )
 
 
+@app.route("/octoprint-emulator/api/settings", methods=["GET"])
+@cross_origin()
+def settings():
+    token = request.headers.get("x-api-key", None)
+    if not token:
+        return abort(403)
+    try:
+        decode_token(token)
+    except Exception as e:
+        abort(403)
+
+    return jsonify(
+        {}
+    )
+
+
+@app.route("/octoprint-emulator/api/printer", methods=["GET"])
+@cross_origin()
+def printer():
+    token = request.headers.get("x-api-key", None)
+    if not token:
+        return abort(403)
+    try:
+        decode_token(token)
+    except Exception as e:
+        abort(403)
+
+    return jsonify(
+        {
+            "sd": {
+                "ready": True
+            },
+            "state": {
+                "flags": {
+                    "cancelling": False,
+                    "closedOrError": False,
+                    "error": False,
+                    "finishing": False,
+                    "operational": True,
+                    "paused": False,
+                    "pausing": False,
+                    "printing": False,
+                    "ready": True,
+                    "resuming": False,
+                    "sdReady": True
+                },
+                "text": "Operational"
+            },
+
+        }
+    )
+
+
+@app.route("/octoprint-emulator/api/job", methods=["GET"])
+@cross_origin()
+def job():
+
+    token = request.headers.get("x-api-key", None)
+    if not token:
+        return abort(403)
+    try:
+        decode_token(token)
+    except Exception as e:
+        abort(403)
+
+    return jsonify(
+        {
+            "job": {
+            }
+
+        }
+    )
+
+
 @app.route("/octoprint-emulator/api/files/local", methods=["POST"])
 @cross_origin()
 def upload():
@@ -46,7 +120,7 @@ def upload():
     if not re.search(r"\.gco(de)?$", incoming.filename):
         return abort(415)
     try:
-        saved = files.save(incoming, request.form.get("path", "/"))
+        saved = files.save(incoming, request.form.get("path", ""))
         gcode_id = gcodes.add_gcode(
             path=saved["path"],
             filename=saved["filename"],
@@ -57,7 +131,7 @@ def upload():
         )
         analyze_gcode.delay(gcode_id)
     except (IOError, OSError) as e:
-        return abort(500, e)
+        return abort(500, "upload IOError;\t" + str(e))
     return (
         jsonify(
             {

--- a/src/karmen_backend/server/routes/octoprintemulator.py
+++ b/src/karmen_backend/server/routes/octoprintemulator.py
@@ -1,5 +1,7 @@
 import re
 
+import functools
+
 from flask import jsonify, request, abort
 from flask_cors import cross_origin
 
@@ -10,16 +12,25 @@ from server.tasks.analyze_gcode import analyze_gcode
 from flask_jwt_extended import decode_token
 
 
+def x_api_key_required(func):
+    @functools.wraps(func)
+    def wrap():
+        token = request.headers.get("x-api-key", None)
+        if not token:
+            return abort(403)
+        try:
+            decode_token(token)
+        except Exception as e:
+            return abort(403)
+        return func()
+
+    return wrap
+
+
 @app.route("/octoprint-emulator/api/version", methods=["GET"])
 @cross_origin()
+@x_api_key_required
 def version():
-    token = request.headers.get("x-api-key", None)
-    if not token:
-        return abort(403)
-    try:
-        decode_token(token)
-    except Exception as e:
-        abort(403)
     return jsonify(
         {"api": "karmen", "text": "OctoPrint emulator by Karmen", "server": __version__}
     )
@@ -27,36 +38,18 @@ def version():
 
 @app.route("/octoprint-emulator/api/settings", methods=["GET"])
 @cross_origin()
+@x_api_key_required
 def settings():
-    token = request.headers.get("x-api-key", None)
-    if not token:
-        return abort(403)
-    try:
-        decode_token(token)
-    except Exception as e:
-        abort(403)
-
-    return jsonify(
-        {}
-    )
+    return jsonify({})
 
 
 @app.route("/octoprint-emulator/api/printer", methods=["GET"])
 @cross_origin()
+@x_api_key_required
 def printer():
-    token = request.headers.get("x-api-key", None)
-    if not token:
-        return abort(403)
-    try:
-        decode_token(token)
-    except Exception as e:
-        abort(403)
-
     return jsonify(
         {
-            "sd": {
-                "ready": True
-            },
+            "sd": {"ready": True},
             "state": {
                 "flags": {
                     "cancelling": False,
@@ -69,34 +62,19 @@ def printer():
                     "printing": False,
                     "ready": True,
                     "resuming": False,
-                    "sdReady": True
+                    "sdReady": True,
                 },
-                "text": "Operational"
+                "text": "Operational",
             },
-
         }
     )
 
 
 @app.route("/octoprint-emulator/api/job", methods=["GET"])
 @cross_origin()
+@x_api_key_required
 def job():
-
-    token = request.headers.get("x-api-key", None)
-    if not token:
-        return abort(403)
-    try:
-        decode_token(token)
-    except Exception as e:
-        abort(403)
-
-    return jsonify(
-        {
-            "job": {
-            }
-
-        }
-    )
+    return jsonify({"job": {}})
 
 
 @app.route("/octoprint-emulator/api/files/local", methods=["POST"])

--- a/src/karmen_backend/tests/routes/test_octoprintemulator.py
+++ b/src/karmen_backend/tests/routes/test_octoprintemulator.py
@@ -85,7 +85,7 @@ class PrinterRoute(unittest.TestCase):
             response = c.get("/octoprint-emulator/api/printer")
             self.assertEqual(response.status_code, 403)
 
-    def test_printe_expired_token(self):
+    def test_printer_expired_token(self):
         with app.test_client() as c:
             response = c.get(
                 "/octoprint-emulator/api/printer",

--- a/src/karmen_backend/tests/routes/test_octoprintemulator.py
+++ b/src/karmen_backend/tests/routes/test_octoprintemulator.py
@@ -32,6 +32,81 @@ class VersionRoute(unittest.TestCase):
             self.assertTrue("OctoPrint" in response.json["text"])
 
 
+class SettingsRoute(unittest.TestCase):
+    def test_settings_no_token(self):
+        with app.test_client() as c:
+            response = c.get("/octoprint-emulator/api/settings")
+            self.assertEqual(response.status_code, 403)
+
+    def test_settings_expired_token(self):
+        with app.test_client() as c:
+            response = c.get(
+                "/octoprint-emulator/api/settings",
+                headers={"X-Api-Key": TOKEN_ADMIN_EXPIRED},
+            )
+            self.assertEqual(response.status_code, 403)
+
+    def test_settings(self):
+        with app.test_client() as c:
+            response = c.get(
+                "/octoprint-emulator/api/settings", headers={"X-Api-Key": TOKEN_USER}
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(len(response.json) == 0)
+
+
+class JobRoute(unittest.TestCase):
+    def test_job_no_token(self):
+        with app.test_client() as c:
+            response = c.get("/octoprint-emulator/api/job")
+            self.assertEqual(response.status_code, 403)
+
+    def test_job_expired_token(self):
+        with app.test_client() as c:
+            response = c.get(
+                "/octoprint-emulator/api/job",
+                headers={"X-Api-Key": TOKEN_ADMIN_EXPIRED},
+            )
+            self.assertEqual(response.status_code, 403)
+
+    def test_job(self):
+        with app.test_client() as c:
+            response = c.get(
+                "/octoprint-emulator/api/job", headers={"X-Api-Key": TOKEN_USER}
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue("job" in response.json)
+            self.assertTrue(response.json["job"] == {})
+
+
+class PrinterRoute(unittest.TestCase):
+    def test_printer_no_token(self):
+        with app.test_client() as c:
+            response = c.get("/octoprint-emulator/api/printer")
+            self.assertEqual(response.status_code, 403)
+
+    def test_printe_expired_token(self):
+        with app.test_client() as c:
+            response = c.get(
+                "/octoprint-emulator/api/printer",
+                headers={"X-Api-Key": TOKEN_ADMIN_EXPIRED},
+            )
+            self.assertEqual(response.status_code, 403)
+
+    def test_printer(self):
+        with app.test_client() as c:
+            response = c.get(
+                "/octoprint-emulator/api/printer", headers={"X-Api-Key": TOKEN_USER}
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue("sd" in response.json)
+            self.assertTrue("ready" in response.json["sd"])
+            self.assertTrue(response.json["sd"]["ready"] == True)
+            self.assertTrue("state" in response.json)
+            self.assertTrue("text" in response.json["state"])
+            self.assertTrue("Operational" == response.json["state"]["text"])
+
+
 class FilesLocalRoute(unittest.TestCase):
     @mock.patch("server.routes.gcodes.analyze_gcode.delay")
     @mock.patch(
@@ -55,7 +130,7 @@ class FilesLocalRoute(unittest.TestCase):
             )
             self.assertEqual(response.status_code, 201)
             args, kwargs = mocked_save.call_args
-            self.assertEqual(args[1], "/")
+            self.assertEqual(args[1], "")
             self.assertEqual(mocked_delay.call_count, 1)
 
     @mock.patch("server.routes.gcodes.gcodes.add_gcode")


### PR DESCRIPTION
Added faked endpoints to octoprint emulator to trick Ultimaker Cuda to accept Karmen as valid OctoPrint printer and allow sending gcodes directly from the Cuda to Karmen