### PR TITLE
Fix/token server url not passed down

### DIFF
--- a/src/karmen_backend/server/services/printer_tokens.py
+++ b/src/karmen_backend/server/services/printer_tokens.py
@@ -35,7 +35,9 @@ class TokenIssuer:
 
     def issue_token(self, user_uuid, iss="kcf"):
         try:
-            resp = self.session.post("/key", data={"iss": iss, "sub": user_uuid})
+            resp = self.session.post(
+                f"{self.api_url}/key", data={"iss": iss, "sub": user_uuid}
+            )
         except (requests.ConnectionError, requests.ConnectTimeout) as exc:
             raise TokenIssuerUnavailable() from exc
 

--- a/src/karmen_frontend/src/actions/utils.js
+++ b/src/karmen_frontend/src/actions/utils.js
@@ -11,7 +11,11 @@ const isPromise = (p) => {
   return p && p.then && p.catch;
 };
 
-export const createThunkedAction = (name, func) => {
+export const createThunkedAction = (
+  name,
+  func,
+  { raiseErrors = false } = {}
+) => {
   return (...args) => (dispatch, getState, extra) => {
     let result;
     dispatch(createActionFactory(`${name}_STARTED`)());
@@ -31,11 +35,16 @@ export const createThunkedAction = (name, func) => {
       return result;
     };
     // when action is not successful because it throws...
-    const failed = (result) => {
+    const failed = (err) => {
       // ... fire fail and end ...
-      dispatch(createActionFactory(`${name}_FAILED`)(result));
-      dispatch(createActionFactory(`${name}_ENDED`)(result));
-      // ... but always return the result
+      dispatch(createActionFactory(`${name}_FAILED`)(err));
+      dispatch(createActionFactory(`${name}_ENDED`)(err));
+
+      // ... if raise is requested, bubble the error up
+      if (raiseErrors) {
+        throw err;
+      }
+      // ... otherwise, return the result
       return result;
     };
 

--- a/src/karmen_frontend/src/actions/utils.js
+++ b/src/karmen_frontend/src/actions/utils.js
@@ -1,3 +1,5 @@
+const RAISE_ERRORS = window.env.RAISE_ERRORS || false;
+
 // inspired by https://github.com/machadogj/redux-thunk-actions/blob/master/src/index.js
 
 const createActionFactory = (type) => {
@@ -14,7 +16,7 @@ const isPromise = (p) => {
 export const createThunkedAction = (
   name,
   func,
-  { raiseErrors = false } = {}
+  { raiseErrors = RAISE_ERRORS } = {}
 ) => {
   return (...args) => (dispatch, getState, extra) => {
     let result;

--- a/src/karmen_frontend/src/services/backend/printers/management.js
+++ b/src/karmen_frontend/src/services/backend/printers/management.js
@@ -55,5 +55,6 @@ export const issuePrinterToken = (orgUuid) => {
   return performRequest({
     uri: `/organizations/${orgUuid}/printers/issue-token`,
     method: "POST",
+    raiseErrors: true,
   });
 };

--- a/src/karmen_frontend/src/services/backend/utils.js
+++ b/src/karmen_frontend/src/services/backend/utils.js
@@ -2,6 +2,7 @@ import dayjs from "dayjs";
 import Cookies from "js-cookie";
 
 const BASE_URL = window.env.BACKEND_BASE;
+const RAISE_ERRORS = window.env.RAISE_ERRORS || false;
 
 const _removeStorage = (key) => {
   try {
@@ -90,7 +91,7 @@ export const performRequest = (opts) => {
       "Content-Type": "application/json",
     },
     useAuth: true,
-    raiseErrors: false,
+    raiseErrors: RAISE_ERRORS,
   };
   opts = Object.assign({}, defaults, opts);
 


### PR DESCRIPTION
This fixes two sorts of problems:

- Token server url from the config wasn't passed down properly
- Error handling on the FE swallowed all errors - I've added an opt-out mechanism for this