### PR TITLE
build failes on a missing build dependency during pip install

### DIFF
--- a/src/karmen_backend/Dockerfile
+++ b/src/karmen_backend/Dockerfile
@@ -1,26 +1,6 @@
-FROM python:3.7-alpine as builder
+FROM python:3.7-alpine
+# for arp-scan (used in self hosted mode of karmen)
 RUN echo "http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
-
-RUN mkdir /install
-WORKDIR /install
-
-# build deps
-RUN apk --update add --no-cache gcc make postgresql-client postgresql-dev openssl-dev libffi-dev jq pcre-dev python3-dev build-base linux-headers
-
-RUN pip install --upgrade pip
-RUN pip install uwsgi supervisor
-
-# Install from lockfile
-COPY Pipfile* ./
-RUN jq -r '.default | to_entries[] | .key + .value.version' \
-    Pipfile.lock > requirements.txt && pip install -r requirements.txt
-
-
-FROM python:3.7-alpine as runner
-RUN echo "http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
-
-# runtime deps
-RUN apk --update add --no-cache nginx gettext avahi avahi-tools arp-scan postgresql-client bash dbus
 
 # ensure www-data user
 RUN set -x ; \
@@ -29,12 +9,21 @@ RUN set -x ; \
 
 WORKDIR /usr/src/app
 
-# Install from cache - no need for system dependencies for this
-COPY --from=builder /root/.cache /root/.cache
-COPY --from=builder /install/requirements.txt requirements.txt
-RUN pip install --upgrade pip
-RUN pip install -r requirements.txt
+# build deps
+RUN apk add --no-cache gcc make postgresql-client postgresql-dev openssl-dev libffi-dev jq pcre-dev python3-dev build-base linux-headers libxml2-dev libxslt-dev
+
+
+RUN pip install --upgrade pipenv pip
+
+# Install from lockfile
+COPY Pipfile* ./
+RUN pipenv install --system --deploy
 RUN pip install uwsgi supervisor
+# build deps
+RUN apk del gcc make postgresql-client postgresql-dev openssl-dev libffi-dev jq pcre-dev python3-dev build-base linux-headers libxml2-dev libxslt-dev
+
+# runtime deps
+RUN apk --update add --no-cache nginx gettext avahi avahi-tools arp-scan postgresql-client bash dbus
 
 ENV PYTHONPATH=$PYTHONPATH:/usr/src/app
 

--- a/src/karmen_backend/Dockerfile
+++ b/src/karmen_backend/Dockerfile
@@ -10,7 +10,7 @@ RUN set -x ; \
 WORKDIR /usr/src/app
 
 # build deps
-RUN apk add --no-cache gcc make postgresql-client postgresql-dev openssl-dev libffi-dev jq pcre-dev python3-dev build-base linux-headers libxml2-dev libxslt-dev
+RUN apk add --update --no-cache gcc make postgresql-client postgresql-dev openssl-dev libffi-dev jq pcre-dev python3-dev build-base linux-headers libxml2-dev libxslt-dev
 
 
 RUN pip install --upgrade pipenv pip
@@ -23,7 +23,7 @@ RUN pip install uwsgi supervisor
 RUN apk del gcc make postgresql-client postgresql-dev openssl-dev libffi-dev jq pcre-dev python3-dev build-base linux-headers libxml2-dev libxslt-dev
 
 # runtime deps
-RUN apk --update add --no-cache nginx gettext avahi avahi-tools arp-scan postgresql-client bash dbus
+RUN apk add --no-cache nginx gettext avahi avahi-tools arp-scan postgresql-client bash dbus
 
 ENV PYTHONPATH=$PYTHONPATH:/usr/src/app
 


### PR DESCRIPTION
I also used my updated version of Docker file on backend (which is IMO simpler and slightly faster)