### PR TITLE
Fixed crash on edge case when user deletes printer after check queue …

### DIFF
--- a/src/karmen_backend/server/tasks/check_printer.py
+++ b/src/karmen_backend/server/tasks/check_printer.py
@@ -9,6 +9,9 @@ from datetime import datetime
 def check_printer(printer_uuid):
     app.logger.debug("Checking printer %s" % printer_uuid)
     raw_printer = printers.get_printer(printer_uuid)
+    if raw_printer is None:
+        app.logger.debug("Printer was deleted during processing queue")
+        return
     raw_client = network_clients.get_network_client(raw_printer["network_client_uuid"])
     printer_data = dict(raw_client)
     printer_data.update(raw_printer)

--- a/src/karmen_backend/server/tasks/check_printer.py
+++ b/src/karmen_backend/server/tasks/check_printer.py
@@ -9,8 +9,9 @@ from datetime import datetime
 def check_printer(printer_uuid):
     app.logger.debug("Checking printer %s" % printer_uuid)
     raw_printer = printers.get_printer(printer_uuid)
+    # todo: The `get_printer` method should raise an exception instead of returning None
     if raw_printer is None:
-        app.logger.debug("Printer was deleted during processing queue")
+        app.logger.info("Printer was deleted after it was scheduled for update.")
         return
     raw_client = network_clients.get_network_client(raw_printer["network_client_uuid"])
     printer_data = dict(raw_client)

--- a/src/karmen_backend/tests/tasks/test_check_printer.py
+++ b/src/karmen_backend/tests/tasks/test_check_printer.py
@@ -629,3 +629,9 @@ class CheckPrinterTest(unittest.TestCase):
         check_printer("298819f5-0119-4e9b-8191-350d931f7ecf")
         self.assertEqual(mock_address.call_count, 0)
         self.assertEqual(mock_hostname.call_count, 0)
+
+    @mock.patch("server.database.printers.get_printer", return_value=None)
+    def test_task_does_not_fail_when_printer_disappeared(self, mock_get_printer):
+        'situation when printer was scheduled for update but was removed in the meantime'
+        result = check_printer("298819f5-0119-4e9b-8191-350d931f7ecf")
+        self.assertIs(result, None)


### PR DESCRIPTION
…was filled, but before it is processed.