### PR TITLE
added missing cypress scripts

### DIFF
--- a/src/karmen_frontend/cypress/package.json
+++ b/src/karmen_frontend/cypress/package.json
@@ -1,7 +1,7 @@
 {
   "name": "karmen-e2e-tests",
   "version": "1.0.0",
-  "description": "",
+  "description": "Integration tests for karmen.",
   "main": "index.js",
   "eslintConfig": {
     "extends": [
@@ -9,7 +9,8 @@
     ]
   },
   "scripts": {
-    "test": "cypress run",
+    "cypress": "cypress open",
+    "test:cypress": "cypress run",
     "lint:cypress": "eslint cypress --ext js",
     "prettier": "prettier --check src/**/*.js cypress/**/*.js",
     "prettier:fix": "prettier --write src/**/*.js cypress/**/*.js"

--- a/src/karmen_frontend/package.json
+++ b/src/karmen_frontend/package.json
@@ -50,14 +50,14 @@
   "version": "0.11.0",
   "scripts": {
     "eject": "react-scripts eject",
-    "cypress": "cd cypress && npm run cypress open",
+    "cypress": "cd cypress && npm run cypress",
     "lint": "eslint src --ext jsx,js",
     "prettier": "prettier --check src/**/*.js cypress/**/*.js",
     "prettier:fix": "prettier --write src/**/*.js cypress/**/*.js",
     "start": "BROWSER=none REACT_APP_GIT_REV='@dev' react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jest-environment-jsdom-sixteen",
-    "test:cypress": "cd cypress && npm cypress run"
+    "test:cypress": "cd cypress && npm run test:cypress"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.9.0",


### PR DESCRIPTION
Added missing cypress scripts to cypress/package.json after cypress was
moved to sepearte directory.
Also fixed scripts from `..frontend/package.json` to point to the right
cypress scripts.