### PR TITLE
fixed '/run/dbus/pid already exists'

### DIFF
--- a/src/karmen_backend/scripts/docker-start.sh
+++ b/src/karmen_backend/scripts/docker-start.sh
@@ -16,6 +16,7 @@ clean_pid_file() {
 
 start_dbus() {
   mkdir -p /var/run/dbus
+  clean_pid_file /var/run/dbus/pid
   /usr/bin/dbus-daemon --config-file=/usr/share/dbus-1/system.conf --print-address
 }
 


### PR DESCRIPTION
this error arised after adding error handling to the file