### PR TITLE
Fixed KeyError in deleting pwd reset request after login.

### DIFF
--- a/src/karmen_backend/server/routes/users_me.py
+++ b/src/karmen_backend/server/routes/users_me.py
@@ -221,7 +221,7 @@ def authenticate_base(include_refresh_token):
     # drop reset pwd key if any
     if local["pwd_reset_key_hash"]:
         local_users.update_local_user(
-            uuid=user["uuid"], pwd_reset_key_hash=None, pwd_reset_key_expires=None
+            user_uuid=user["uuid"], pwd_reset_key_hash=None, pwd_reset_key_expires=None
         )
 
     userdata = dict(user)

--- a/src/karmen_backend/tests/routes/test_users_me.py
+++ b/src/karmen_backend/tests/routes/test_users_me.py
@@ -325,6 +325,20 @@ class RequestResetPasswordRoute(unittest.TestCase):
             self.assertTrue(args[1][0][2]["pwd_reset_key_expires"] is not None)
             self.assertEqual(args[1][0][2]["email"], email)
 
+    def test_login__still_works_after_reset_request(self):
+        with app.test_client() as c:
+            response = c.post(
+                "/users/me/request-password-reset",
+                json={"email": "test-admin@karmen.local"},
+            )
+            self.assertEqual(response.status_code, 202)
+
+            response = c.post(
+                "/users/me/authenticate",
+                json={"username": "test-admin", "password": "admin-password"},
+            )
+            self.assertEqual(response.status_code, 200)
+
 
 class ResetPasswordRoute(unittest.TestCase):
     def setUp(self):

--- a/src/karmen_backend/tests/tasks/test_check_printer.py
+++ b/src/karmen_backend/tests/tasks/test_check_printer.py
@@ -632,6 +632,6 @@ class CheckPrinterTest(unittest.TestCase):
 
     @mock.patch("server.database.printers.get_printer", return_value=None)
     def test_task_does_not_fail_when_printer_disappeared(self, mock_get_printer):
-        'situation when printer was scheduled for update but was removed in the meantime'
+        "situation when printer was scheduled for update but was removed in the meantime"
         result = check_printer("298819f5-0119-4e9b-8191-350d931f7ecf")
         self.assertIs(result, None)


### PR DESCRIPTION
When user requests pwd reset and then remembers the password and tries to login without clicking the reset link, the app crashed. This was caused by wrong argument name in the update function, which deletes the pwd reset request if user logs in. 