### PR TITLE
Feat/cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tmp
 .idea
 .vscode
 src/karmen_frontend/cypress/screenshots
+local.env

--- a/.travis/make-github-release.sh
+++ b/.travis/make-github-release.sh
@@ -16,9 +16,9 @@ cp ../docker-compose.release.yml "${DEST}/docker-compose.yml"
 echo "${TRAVIS_BRANCH-latest}" > "${DEST}/VERSION"
 
 # Hardcode version into docker-compose
-sed -i "s/fragaria\/karmen-frontend/fragaria\/karmen-frontend:${TRAVIS_BRANCH-latest}/g" "${DEST}/docker-compose.yml"
-sed -i "s/fragaria\/karmen-backend/fragaria\/karmen-backend:${TRAVIS_BRANCH-latest}/g" "${DEST}/docker-compose.yml"
-sed -i "s/fragaria\/karmen-proxy/fragaria\/karmen-proxy:${TRAVIS_BRANCH-latest}/g" "${DEST}/docker-compose.yml"
+sed -i "s!fragaria/karmen-frontend!fragaria/karmen-frontend:${TRAVIS_BRANCH-latest}!g" "${DEST}/docker-compose.yml"
+sed -i "s!fragaria/karmen-backend!fragaria/karmen-backend:${TRAVIS_BRANCH-latest}!g" "${DEST}/docker-compose.yml"
+sed -i "s!fragaria/karmen-proxy!fragaria/karmen-proxy:${TRAVIS_BRANCH-latest}!g" "${DEST}/docker-compose.yml"
 
 # Prepare run script
 cat << "EOF" > "$DEST/run-karmen.sh"

--- a/README.md
+++ b/README.md
@@ -41,23 +41,32 @@ $ docker-compose up --build
 # GO VISIT http://localhost:4000/
 ```
 
+If you want to connect to an internals of a service run `docker-compose exec
+<service> <command>` from root of project. Where `<service>` is the name os the service as defined
+in `docker-compose.yml`.
+
+Examples:
+
+- to connect to postgres: `docker-compose exec postgres psql -U print3d print3d` (with the default configuration).
+- to connect to running backend: `docker-compose exec backend bash`
+
+
 There are two modes available. They differ in the way the printers are connected to Karmen Hub.
 
 1. **Cloud Mode**
     This mode is used when Karmen Hub is run as a service on the internet. The printers are connected
     via [websocket proxy](https://github.com/fragaria/websocket-proxy) that is tunnelling the network connection
     to Octoprint or other compatible API. In this mode, the autodiscovery feature is disabled. This is
-    the default mode for development.
+    the default mode.
+
 1. **Local Mode**
     This can be used when Karmen Hub is run on premise with access to printers via local network.
-    In this mode, you can add printers by running the autodiscovery task.
-
-You can switch between the modes by using `KARMEN_CLOUD_MODE` environment variable, i. e.
-`KARMEN_CLOUD_MODE=0 docker-compose up --build` will run Karmen Hub in the local mode. 
+    In this mode, you can add printers by running the autodiscovery task. Set
+    `CLOUD_MODE=1` in `loca.env` file to switch to this mode.
 
 The network autodiscovery via ARP does not work at all in the dev mode.
 
-On the other hand, two fake virtual printers are automatically added to your envirnoment, so you have a few
+On the other hand, three fake virtual printers are automatically added to your envirnoment, so you have a few
 things to play with.
 
 Also, there are at least two users available in the fresh dev environment:
@@ -68,7 +77,11 @@ printers.
 
 All of the g-codes are currently shared across all user accounts in an organization.
 
-**Note**: If something suddenly breaks within this setup, try to clean docker with `docker system prune`, it might help.
+To change a configuration edit [local.env](./local.env) file and follow instructions.
+
+**Note**: If something suddenly breaks within this setup, try to clean docker
+with `docker system prune` or delete `tmp/db-data` and `tmp/karmen-files` it
+might help.
 
 ## Backend API Specification
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ There are two modes available. They differ in the way the printers are connected
 1. **Local Mode**
     This can be used when Karmen Hub is run on premise with access to printers via local network.
     In this mode, you can add printers by running the autodiscovery task. Set
-    `CLOUD_MODE=1` in `loca.env` file to switch to this mode.
+    `CLOUD_MODE=0` in `loca.env` file to switch to this mode.
 
 The network autodiscovery via ARP does not work at all in the dev mode.
 

--- a/base.env
+++ b/base.env
@@ -1,0 +1,59 @@
+# Base configuration file for Karmen.
+#
+# Please note that, this is an .env file not a shell script, values are not
+# interpreted in any way (nor substiued).
+#
+# This configuration file contains the default values for all settings together
+# with brief description. Do not change values here. Add your customized values
+# to `local.env` files in this directory, which is ignored from git and package
+# updates.
+
+# secret key used to encrypt application tokens
+SECRET_KEY=
+
+# url websocket_server listens to
+# http://websocket.server.host:8090/api/%s
+SOCKET_API_URL=
+
+# the entry point of backend api
+BACKEND_BASE=/api
+
+# token server (verifies pill keys if configured in websocket_server)
+# used to generate new keys for non-pill devices
+TOKEN_SERVER_API_URL=
+
+# where the frontend listens on
+FRONTEND_BASE_URL=http://localhost:4000
+
+# mailer configuratio
+# case insensitive name of mailer: dummy, mailgun, ses, smtp, console
+MAILER=Dummy
+
+# json configuration passed to the mailer
+MAILER_CONFIG={}
+
+# sender of mails
+MAILER_FROM=Karmen <karmen@karmen.local>
+
+
+# sentry configuration, consult sentry documentation 
+# errors will not be sent to sentry if unset
+SENTRY_DSN=
+
+# target environment do not change on production servers
+ENV=production
+IS_DEV_ENV=0
+
+POSTGRES_DB=print3d
+POSTGRES_PASSWORD=print3d
+POSTGRES_USER=print3d
+# 1 - run in SaS mode, 0 - deprecated - runs locally
+CLOUD_MODE=1
+NETWORK_TIMEOUT=5
+NETWORK_VERIFY_CERTIFICATES=1
+
+# service names as defined in docker-compose file
+FRONTEND_HOST=frontend
+BACKEND_HOST=backend_flask
+REDIS_HOST=redis
+POSTGRES_HOST=postgres

--- a/dev.env
+++ b/dev.env
@@ -1,0 +1,9 @@
+SOCKET_API_URL=http://fake_ws_proxy:9999/api/%s
+FRONTEND_BASE_URL=http://localhost:4000
+MAILER=DUMMY
+ENV=develop
+RAISE_ERRORS=1
+MAILER_FROM=Karmen <karmen@karmen.local>
+TOKEN_SERVER_API_URL=http://key_issuer:8422
+LOCAL_TESTS_TOKEN=random-test-token
+SECRET_KEY=random-secret!-but-better===========

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -1,174 +1,60 @@
+# This file is used by .travis/make-github-release.sh to create a release bundle.
+# The script replaces all image names to include docker tag published to
+# dockerhub.io for the respective version.
 version: "3.4"
+
 services:
   proxy:
     image: fragaria/karmen-proxy
     restart: unless-stopped
-    network_mode: host
-    environment:
-      SERVICE_HOST: ${KARMEN_HOST:-0.0.0.0}
-      SERVICE_PORT: ${KARMEN_PORT:-80}
-      FRONTEND_HOST: ${KARMEN_FRONTEND_HOST:-127.0.0.1}
-      FRONTEND_PORT: ${KARMEN_FRONTEND_PORT:-9765}
-      BACKEND_HOST: ${KARMEN_BACKEND_HOST:-127.0.0.1}
-      BACKEND_PORT: ${KARMEN_BACKEND_PORT:-9764}
-      IS_DEV_ENV: 0
+    env_file: [base.env, local.env]
     depends_on:
       - frontend
       - backend_flask
+    ports:
+      - ${KARMEN_HOST:-127.0.0.1}:${KARMEN_PORT:-4000}:9766 # TODO: set as env
+
   frontend:
     image: fragaria/karmen-frontend
-    network_mode: host
     restart: unless-stopped
-    environment:
-      ENV: production
-      BACKEND_BASE: /api
-      SERVICE_HOST: ${KARMEN_FRONTEND_HOST:-127.0.0.1}
-      SERVICE_PORT: ${KARMEN_FRONTEND_PORT:-9765}
-      SENTRY_DSN: ${KARMEN_FRONTEND_SENTRY_DSN}
-      CLOUD_MODE: ${KARMEN_CLOUD_MODE:-0}
-  backend_flask:
+    env_file: [base.env, local.env]
+
+  backend_flask: &backend_flask  # <-- bookmark
     image: fragaria/karmen-backend
     restart: unless-stopped
-    network_mode: host # for arp-scan
+    # runs initialization first (solved elsewehre in production)
+    command: bash -c './scripts/migrate.sh && ./scripts/docker-start.sh'
+    env_file: [base.env, local.env]
     environment:
-      ENV: production
       SERVICE: flask
-      CLOUD_MODE: ${KARMEN_CLOUD_MODE:-0}
-      FRONTEND_BASE_URL: ${KARMEN_FRONTEND_BASE_URL}
-      MAILER: ${KARMEN_MAILER:-DUMMY}
-      MAILER_CONFIG: ${KARMEN_MAILER_CONFIG}
-      MAILER_FROM: ${KARMEN_MAILER_FROM:-Karmen <karmen@karmen.local>}
-      NETWORK_TIMEOUT: ${KARMEN_NETWORK_TIMEOUT:-5}
-      NETWORK_VERIFY_CERTIFICATES: ${NETWORK_VERIFY_CERTIFICATES:-1}
-      POSTGRES_DB: ${KARMEN_POSTGRES_DB:-print3d}
-      POSTGRES_HOST: ${KARMEN_POSTGRES_HOST:-127.0.0.1}
-      POSTGRES_PASSWORD: ${KARMEN_POSTGRES_PASSWORD:-print3d}
-      POSTGRES_PORT: ${KARMEN_POSTGRES_PORT:-5433}
-      POSTGRES_USER: ${KARMEN_POSTGRES_USER:-print3d}
-      REDIS_HOST: ${KARMEN_REDIS_HOST:-127.0.0.1}
-      REDIS_PORT: ${KARMEN_REDIS_PORT:-6379}
-      SECRET_KEY: ${KARMEN_SECRET_KEY}
-      SENTRY_DSN: ${KARMEN_BACKEND_SENTRY_DSN}
-      SERVICE_HOST: ${KARMEN_BACKEND_HOST:-127.0.0.1}
-      SERVICE_PORT: ${KARMEN_BACKEND_PORT:-9764}
-      SOCKET_API_URL: ${KARMEN_SOCKET_API_URL}
-      UPLOAD_FOLDER: ${KARMEN_UPLOAD_FOLDER:-/tmp/karmen-files}
-      TOKEN_SERVER_API_URL: ${KARMEN_TOKEN_SERVER_API_URL:-}
     volumes:
-      - ${KARMEN_UPLOAD_FOLDER:-./karmen-files}:/tmp/karmen-files
-      - /var/run/dbus:/var/run/dbus # for mdns resolution
-    privileged: true # for mdns resolution
+      - ./karmen-files:/tmp/karmen-files
     depends_on:
-      - files
       - redis
-      - dbmigrations
-  files:
-    image: fragaria/karmen-backend
-    user: root
-    command: bash -c 'chown -R www-data:www-data /tmp/karmen-files && chmod -R g+sw /tmp/karmen-files'
-    volumes:
-      - ${KARMEN_UPLOAD_FOLDER:-./karmen-files}:/tmp/karmen-files
-  dbfiles:
-    image: fragaria/karmen-backend
-    user: root
-    command: bash -c 'chown -R 1000:1000 /var/lib/postgresql/data && chmod -R g+sw /var/lib/postgresql/data'
-    volumes:
-      - ${KARMEN_DB_DIR:-./db/data}:/var/lib/postgresql/data
-  dbmigrations:
-    image: fragaria/karmen-backend
-    network_mode: host
-    command: scripts/migrate.sh
-    environment:
-      ENV: production
-      REDIS_HOST: ${KARMEN_REDIS_HOST:-127.0.0.1}
-      REDIS_PORT: ${KARMEN_REDIS_PORT:-6379}
-      POSTGRES_HOST: ${KARMEN_POSTGRES_HOST:-127.0.0.1}
-      POSTGRES_PORT: ${KARMEN_POSTGRES_PORT:-5433}
-      POSTGRES_DB: ${KARMEN_POSTGRES_DB:-print3d}
-      POSTGRES_PASSWORD: ${KARMEN_POSTGRES_PASSWORD:-print3d}
-      POSTGRES_USER: ${KARMEN_POSTGRES_USER:-print3d}
-    depends_on:
-      - postgres
+
   backend_celery_worker:
-    image: fragaria/karmen-backend
-    restart: unless-stopped
-    network_mode: host # for arp discovery, requires a different config for redis/postgres conection
+    <<: *backend_flask  # <-- reuse items from &backend_flask bookmark
+    command: scripts/docker-start.sh
+    env_file: [base.env, local.env]
     environment:
-      ENV: production
       SERVICE: celery-worker
-      CLOUD_MODE: ${KARMEN_CLOUD_MODE:-0}
-      FRONTEND_BASE_URL: ${KARMEN_FRONTEND_BASE_URL}
-      MAILER: ${KARMEN_MAILER:-DUMMY}
-      MAILER_CONFIG: ${KARMEN_MAILER_CONFIG}
-      MAILER_FROM: ${KARMEN_MAILER_FROM:-Karmen <karmen@karmen.local>}
-      NETWORK_TIMEOUT: ${KARMEN_NETWORK_TIMEOUT:-5}
-      NETWORK_VERIFY_CERTIFICATES: ${NETWORK_VERIFY_CERTIFICATES:-1}
-      POSTGRES_DB: ${KARMEN_POSTGRES_DB:-print3d}
-      POSTGRES_HOST: ${KARMEN_POSTGRES_HOST:-127.0.0.1}
-      POSTGRES_PASSWORD: ${KARMEN_POSTGRES_PASSWORD:-print3d}
-      POSTGRES_PORT: ${KARMEN_POSTGRES_PORT:-5433}
-      POSTGRES_USER: ${KARMEN_POSTGRES_USER:-print3d}
-      REDIS_HOST: ${KARMEN_REDIS_HOST:-127.0.0.1}
-      REDIS_PORT: ${KARMEN_REDIS_PORT:-6379}
-      SECRET_KEY: ${KARMEN_SECRET_KEY}
-      SENTRY_DSN: ${KARMEN_BACKEND_SENTRY_DSN}
-      SERVICE_HOST: ${KARMEN_BACKEND_HOST:-127.0.0.1}
-      SERVICE_PORT: ${KARMEN_BACKEND_PORT:-9764}
-      SOCKET_API_URL: ${KARMEN_SOCKET_API_URL}
-      UPLOAD_FOLDER: ${KARMEN_UPLOAD_FOLDER:-/tmp/karmen-files}
-    volumes:
-      - ${KARMEN_UPLOAD_FOLDER:-./karmen-files}:/tmp/karmen-files
-      - /var/run/dbus:/var/run/dbus # for mdns resolution
-    privileged: true # for mdns resolution
-    depends_on:
-      - dbmigrations
-      - redis
+
   backend_celery_beat:
-    image: fragaria/karmen-backend
-    restart: unless-stopped
-    network_mode: host
+    <<: *backend_flask
+    command: scripts/docker-start.sh
+    env_file: [base.env, local.env]
     environment:
-      ENV: production
       SERVICE: celery-beat
-      CLOUD_MODE: ${KARMEN_CLOUD_MODE:-0}
-      FRONTEND_BASE_URL: ${KARMEN_FRONTEND_BASE_URL}
-      MAILER: ${KARMEN_MAILER:-DUMMY}
-      MAILER_CONFIG: ${KARMEN_MAILER_CONFIG}
-      MAILER_FROM: ${KARMEN_MAILER_FROM:-Karmen <karmen@karmen.local>}
-      NETWORK_TIMEOUT: ${KARMEN_NETWORK_TIMEOUT:-5}
-      NETWORK_VERIFY_CERTIFICATES: ${NETWORK_VERIFY_CERTIFICATES:-1}
-      POSTGRES_DB: ${KARMEN_POSTGRES_DB:-print3d}
-      POSTGRES_HOST: ${KARMEN_POSTGRES_HOST:-127.0.0.1}
-      POSTGRES_PASSWORD: ${KARMEN_POSTGRES_PASSWORD:-print3d}
-      POSTGRES_PORT: ${KARMEN_POSTGRES_PORT:-5433}
-      POSTGRES_USER: ${KARMEN_POSTGRES_USER:-print3d}
-      REDIS_HOST: ${KARMEN_REDIS_HOST:-127.0.0.1}
-      REDIS_PORT: ${KARMEN_REDIS_PORT:-6379}
-      SECRET_KEY: ${KARMEN_SECRET_KEY}
-      SENTRY_DSN: ${KARMEN_BACKEND_SENTRY_DSN}
-      SERVICE_HOST: ${KARMEN_BACKEND_HOST:-127.0.0.1}
-      SERVICE_PORT: ${KARMEN_BACKEND_PORT:-9764}
-      SOCKET_API_URL: ${KARMEN_SOCKET_API_URL}
-      UPLOAD_FOLDER: ${KARMEN_UPLOAD_FOLDER:-/tmp/karmen-files}
-    privileged: true # for mdns resolution
-    depends_on:
-      - dbmigrations
-      - redis
-  redis:
-    image: redis:5
-    ports:
-      - 127.0.0.1:${KARMEN_REDIS_PORT:-6379}:6379
+    volumes: []
+
   postgres:
     image: postgres:11
-    user: '1000:1000'
     restart: unless-stopped
     volumes:
       - ${KARMEN_DB_DIR:-./db/data}:/var/lib/postgresql/data
-    environment:
-      POSTGRES_DB: ${KARMEN_POSTGRES_DB:-print3d}
-      POSTGRES_PASSWORD: ${KARMEN_POSTGRES_PASSWORD:-print3d}
-      POSTGRES_USER: ${KARMEN_POSTGRES_USER:-print3d}
-    depends_on:
-      - dbfiles
-    ports:
-      - 127.0.0.1:${KARMEN_POSTGRES_PORT:-5433}:5432
+    env_file: [base.env, local.env]
+
+  redis:
+    image: redis:5
+    restart: unless-stopped
+    env_file: [base.env, local.env]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,238 +1,124 @@
 # This is for development only! Do not run a production instance from this blueprint.
 version: "3.4"
 services:
+
   proxy:
     image: fragaria/karmen-proxy
     build: ./src/proxy
+    env_file: [base.env, dev.env, local.env]
     ports:
       - 127.0.0.1:4000:9766
-    environment:
-      REDIS_HOST: redis
-      IS_DEV_ENV: 1
-    networks:
-      - backend
-      - default
-    depends_on:
-      - frontend
-      - backend_flask
+    networks: [ backend, default ]
+    depends_on: [ frontend, backend_flask, fake_ws_proxy ]
+
   frontend:
     image: fragaria/karmen-frontend
     build: ./src/karmen_frontend
-    environment:
-      ENV: develop
-      CLOUD_MODE: ${KARMEN_CLOUD_MODE:-1}
-      RAISE_ERRORS: ${KARMEN_FRONTEND_RAISE_ERRORS:-1}
-      SENTRY_DSN: ${KARMEN_FRONTEND_SENTRY_DSN:-} # Useful when testing whether sentry errors are captured locally
+    env_file: [base.env, dev.env, local.env]
     ports:
       - 127.0.0.1:3000:9765
     tty: true
     volumes:
       - ./src/karmen_frontend/src:/usr/src/app/src
       - ./src/karmen_frontend/public:/usr/src/app/public
-    networks:
-      - default
-  backend_flask:
+
+  backend_flask: &backend_flask  # <-- bookmark
     image: fragaria/karmen-backend
     build: ./src/karmen_backend
+    command: bash -c './scripts/migrate.sh && ./scripts/docker-start.sh'
+    env_file: [base.env, dev.env, local.env]
     environment:
-      ENV: develop
       SERVICE: flask
-      NETWORK_TIMEOUT: 5
-      NETWORK_VERIFY_CERTIFICATES: 1
-      SECRET_KEY: random-secret!-but-better===========
-      REDIS_HOST: redis
-      POSTGRES_HOST: postgres
-      POSTGRES_PORT: 5432
-      POSTGRES_PASSWORD: print3d
-      POSTGRES_USER: print3d
-      POSTGRES_DB: print3d
-      CLOUD_MODE: ${KARMEN_CLOUD_MODE:-1}
-      SOCKET_API_URL: ${KARMEN_SOCKET_API_URL:-http://fake_ws_proxy:9999/api/%s}
-      FRONTEND_BASE_URL: ${FRONTEND_BASE_URL:-http://localhost:4000}
-      MAILER: ${KARMEN_MAILER:-DUMMY}
-      MAILER_CONFIG: ${KARMEN_MAILER_CONFIG}
-      MAILER_FROM: ${KARMEN_MAILER_FROM:-Karmen <karmen@karmen.local>}
-      TOKEN_SERVER_API_URL: ${KARMEN_TOKEN_SERVER_API_URL:-http://key_issuer:8422}
-      # This token is to enable local admin used for tests and to verify requests to it
-      LOCAL_TESTS_TOKEN: ${KARMEN_LOCAL_TESTS_TOKEN:-random-test-token}
     ports:
       - 127.0.0.1:5000:9764
     volumes:
       - ./src/karmen_backend/server:/usr/src/app/server
       - ./tmp/karmen-files:/tmp/karmen-files
-    networks:
-      - default
-      - printers
-      - backend
-    depends_on:
-      - files
-      - dbmigrations
-    links:
-      - postgres
-      - redis
-  files:
-    image: fragaria/karmen-backend
-    build: ./src/karmen_backend
-    user: root
-    command: bash -c 'chown -R www-data:www-data /tmp/karmen-files && chmod -R g+sw /tmp/karmen-files'
-    volumes:
-      - ./tmp/karmen-files:/tmp/karmen-files
-  dbfiles:
-    image: fragaria/karmen-backend
-    build: ./src/karmen_backend
-    user: root
-    command: bash -c 'chown -R 1000:1000 /var/lib/postgresql/data && chmod -R g+sw /var/lib/postgresql/data'
+    networks: [ printers, backend ]
+    depends_on: [ postgres ]
+    links: [ postgres, redis ]
+
+  postgres:
+    image: postgres:11
+    restart: unless-stopped
+    env_file: [base.env, dev.env, local.env]
     volumes:
       - ./tmp/db-data:/var/lib/postgresql/data
-  dbmigrations:
-    image: fragaria/karmen-backend
-    build: ./src/karmen_backend
-    command: scripts/migrate.sh
+    ports:
+      - 127.0.0.1:5433:5432
+    networks: [ backend ]
+
+  backend_celery_worker:
+    <<: *backend_flask  # <-- reuse items from &backend_flask bookmark
+    # ... but skip migrations in backend_flask `command` property
+    command: scripts/docker-start.sh
     environment:
-      ENV: develop
-      POSTGRES_HOST: postgres
-      POSTGRES_PORT: 5432
-      POSTGRES_PASSWORD: print3d
-      POSTGRES_USER: print3d
-      POSTGRES_DB: print3d
-    depends_on:
-      - postgres
-    networks:
-      - default
-    links:
-      - postgres
+      SERVICE: celery-worker
+    ports: []
+
+  backend_celery_beat:
+    <<: *backend_flask  # <-- reuse items from &backend_flask bookmark
+    # ... but skip migrations in backend_flask `command` property
+    command: scripts/docker-start.sh
+    environment:
+      SERVICE: celery-beat
+    ports: []
+    networks: [ backend ]
+    links: [ redis ]
+
+  redis:
+    image: redis:5
+    env_file: [base.env, dev.env, local.env]
+    networks: [ backend ]
+
   dummymailserver:
     image: fragaria/karmen-dummymailserver
     build: ./src/dummymailserver
-    environment:
-      SERVICE_PORT: 8088
-    networks:
-      - backend
-      - default
+    env_file: [base.env, dev.env, local.env]
+    networks: [ backend ]
     ports:
       - 127.0.0.1:8088:8088
+
   fake_printer1:
     image: fragaria/karmen-fakeprinter
     build: ./src/fakeprinter
+    env_file: [base.env, dev.env, local.env]
     environment:
-      SERVICE_PORT: 8080
       STATE_JOB_NAME: "fake-file-being-printed.gcode"
     networks:
       printers:
         ipv4_address: 172.16.236.11
+
   fake_printer2:
     image: fragaria/karmen-fakeprinter
     build: ./src/fakeprinter
     environment:
-      SERVICE_PORT: 8080
       STATE_JOB_NAME: "fake-file-being-printed.gcode"
     networks:
       printers:
         ipv4_address: 172.16.236.12
+
   fake_printer3:
     image: fragaria/karmen-fakeprinter
     build: ./src/fakeprinter
     environment:
-      SERVICE_PORT: 8080
       STATE_JOB_STATE: "Operational"
     networks:
       printers:
         ipv4_address: 172.16.236.13
+
   fake_ws_proxy:
     image: fragaria/karmen-fakewsproxy
     build: ./src/fakewsproxy
-    environment:
-      SERVICE_PORT: 9999
-    networks:
-      - default
-      - printers
+    networks: [ backend, printers ]
+
   key_issuer:
     image: fragaria/karmen-key-master
     environment:
       SECRET: 'your-super-secret-and-backed-up-private-keymaster-key'
       MAX_SUB_LENGTH: 64
-    networks:
-      - default
-      - backend
-  backend_celery_worker:
-    image: fragaria/karmen-backend
-    build: ./src/karmen_backend
-    environment:
-      ENV: develop
-      SERVICE: celery-worker
-      NETWORK_TIMEOUT: 5
-      NETWORK_VERIFY_CERTIFICATES: 1
-      SECRET_KEY: random-secret!-but-better===========
-      REDIS_HOST: redis
-      POSTGRES_HOST: postgres
-      POSTGRES_PORT: 5432
-      POSTGRES_PASSWORD: print3d
-      POSTGRES_USER: print3d
-      POSTGRES_DB: print3d
-      CLOUD_MODE: ${KARMEN_CLOUD_MODE:-1}
-      SOCKET_API_URL: ${KARMEN_SOCKET_API_URL:-http://fake_ws_proxy:9999/api/%s}
-      FRONTEND_BASE_URL: ${FRONTEND_BASE_URL:-http://localhost:4000}
-      MAILER: ${KARMEN_MAILER:-DUMMY}
-      MAILER_CONFIG: ${KARMEN_MAILER_CONFIG}
-      MAILER_FROM: ${KARMEN_MAILER_FROM:-Karmen <karmen@karmen.local>}
-    volumes:
-      - ./src/karmen_backend/server:/usr/src/app/server
-      - ./tmp/karmen-files:/tmp/karmen-files
-    networks:
-      - default
-      - backend
-      - printers
-    links:
-      - postgres
-      - redis
-  backend_celery_beat:
-    image: fragaria/karmen-backend
-    build: ./src/karmen_backend
-    environment:
-      ENV: develop
-      SERVICE: celery-beat
-      NETWORK_TIMEOUT: 5
-      NETWORK_VERIFY_CERTIFICATES: 1
-      SECRET_KEY: random-secret!-but-better===========
-      REDIS_HOST: redis
-      POSTGRES_HOST: postgres
-      POSTGRES_PORT: 5432
-      POSTGRES_PASSWORD: print3d
-      POSTGRES_USER: print3d
-      POSTGRES_DB: print3d
-      CLOUD_MODE: ${KARMEN_CLOUD_MODE:-1}
-      SOCKET_API_URL: ${KARMEN_SOCKET_API_URL:-http://fake_ws_proxy:9999/api/%s}
-      FRONTEND_BASE_URL: ${FRONTEND_BASE_URL:-http://localhost:4000}
-      MAILER: ${KARMEN_MAILER:-DUMMY}
-      MAILER_CONFIG: ${KARMEN_MAILER_CONFIG}
-      MAILER_FROM: ${KARMEN_MAILER_FROM:-Karmen <karmen@karmen.local>}
-    volumes:
-      - ./src/karmen_backend/server:/usr/src/app/server
-    networks:
-      - backend
-    links:
-      - redis
-  redis:
-    image: redis:5
-    networks:
-      - backend
-  postgres:
-    image: postgres:11
-    user: '1000:1000'
-    restart: unless-stopped
-    volumes:
-      - ./tmp/db-data:/var/lib/postgresql/data
-    environment:
-      POSTGRES_PASSWORD: print3d
-      POSTGRES_USER: print3d
-      POSTGRES_DB: print3d
-    depends_on:
-      - dbfiles
-    ports:
-      - 127.0.0.1:5433:5432
-    networks:
-      - default
-      - backend
+    networks: [ backend ]
+
   api_doc:
     image: redocly/redoc
     environment:
@@ -240,16 +126,18 @@ services:
       PAGE_FAVICON: ${FRONTEND_BASE_URL:-http://localhost:4000}/favicon.ico
       SPEC_URL: ${BACKEND_BASE_URL:-http://localhost:4000}/api/openapi-spec.yaml
       PORT: 9898
-    networks:
-      - default
-      - backend
-    depends_on:
-      - backend_flask
+    networks: [ default, backend ]
+    depends_on: [ backend_flask ]
+
 networks:
-  backend:
+  # backend network - must not be reachable by users
+  backend: 
     ipam:
       config:
       - subnet: 172.16.235.0/24
+
+  # printers - should be on a different network accessible only through
+  # websocket proxy server
   printers:
     ipam:
       config:

--- a/local.env
+++ b/local.env
@@ -1,0 +1,6 @@
+# This is the place where to add your custom configuration which will not be
+# propagated back to git.
+# While this file is ignored from git, a template is in the repository source
+# tree for your convenience.
+#
+# To see list of all possible configurations refer to `base.env` file.

--- a/src/dummymailserver/Dockerfile
+++ b/src/dummymailserver/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get remove --purge --yes gcc make postgresql-client libpq-dev libffi-dev
 
 ENV PYTHONPATH=$PYTHONPATH:/usr/src/app
 ENV SERVICE_HOST 0.0.0.0
-ENV SERVICE_PORT 9767
+ENV SERVICE_PORT 8088
 
 COPY . .
 CMD ["./scripts/docker-start.sh"]

--- a/src/dummymailserver/README.md
+++ b/src/dummymailserver/README.md
@@ -10,11 +10,11 @@ The preferred way is to use the composed docker package as [described in here](.
 
 ```sh
 docker build -t fragaria/karmen-dummymailserver .
-docker run -p8080:8080 fragaria/karmen-dummymailserver
+docker run -p8080:8088 fragaria/karmen-dummymailserver
 ```
 
 You can control the exposed interface and port with the following environment variables. This is useful when container is
 run in the docker's networking host mode.
 
 - `SERVICE_HOST` - Interface on which the proxy will be exposed, defaults to `0.0.0.0`. 
-- `SERVICE_PORT` - Port on which the proxy will be exposed, defaults to `9767`
+- `SERVICE_PORT` - Port on which the proxy will be exposed, defaults to `8088`

--- a/src/dummymailserver/scripts/docker-start.sh
+++ b/src/dummymailserver/scripts/docker-start.sh
@@ -2,4 +2,4 @@
 
 export FLASK_APP=dummymailserver
 export FLASK_DEBUG=true
-flask run --host=${SERVICE_HOST:-0.0.0.0} --port ${SERVICE_PORT:-9767}
+flask run --host=$SERVICE_HOST --port $SERVICE_PORT

--- a/src/fakeprinter/scripts/docker-start.sh
+++ b/src/fakeprinter/scripts/docker-start.sh
@@ -2,4 +2,4 @@
 
 export FLASK_APP=fakeprinter
 export FLASK_DEBUG=true
-flask run --host=${SERVICE_HOST:-0.0.0.0} --port ${SERVICE_PORT:-9766}
+flask run --host=$SERVICE_HOST --port $SERVICE_PORT

--- a/src/fakewsproxy/Dockerfile
+++ b/src/fakewsproxy/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src/app
 RUN apk --update add --no-cache nginx bash gettext
 
 ENV SERVICE_HOST 0.0.0.0
-ENV SERVICE_PORT 9768
+ENV SERVICE_PORT 9999
 
 COPY ./scripts/nginx.conf.template /etc/nginx/nginx.conf.template
 COPY ./scripts scripts

--- a/src/karmen_backend/Dockerfile
+++ b/src/karmen_backend/Dockerfile
@@ -11,6 +11,11 @@ RUN set -e && pip install --upgrade pip pipenv
 RUN set -e && apt-get install --yes libxml2-dev libxslt-dev nginx gettext avahi-utils arp-scan dbus
 RUN set -e && pip install uwsgi supervisor
 
+# set permition for upload directory (to mount later)
+RUN mkdir /tmp/karmen-files \
+    && chown www-data:www-data /tmp/karmen-files \
+    && chmod -R g+sw /tmp/karmen-files
+
 # Install from lockfile
 COPY Pipfile* ./
 RUN set -e && pipenv lock -r > requirements.pip && pip install -r requirements.pip
@@ -39,4 +44,4 @@ COPY ./scripts/supervisord.conf /etc/supervisord.conf
 
 COPY . .
 
-CMD ["./scripts/docker-start.sh"]
+CMD ./scripts/docker-start.sh

--- a/src/karmen_backend/Makefile
+++ b/src/karmen_backend/Makefile
@@ -39,7 +39,7 @@ test: run-docker-test-redis run-docker-test-postgres
 	CELERY_CONFIG=${CELERY_CONFIG} \
 	SECRET_KEY=${SECRET_KEY} \
 	LOCAL_TESTS_TOKEN="${LOCAL_TESTS_TOKEN}" \
-	  pytest -n auto --dist=loadscope
+	  pytest -n auto --dist=loadscope $(test_args)
 	@-docker stop karmen_pg_test
 	@-docker rm karmen_pg_test
 	@-docker stop karmen_redis_test
@@ -66,7 +66,7 @@ test-watch: run-docker-test-redis run-docker-test-postgres
 	CELERY_CONFIG=${CELERY_CONFIG} \
 	SECRET_KEY=${SECRET_KEY} \
 	LOCAL_TESTS_TOKEN="${LOCAL_TESTS_TOKEN}" \
-	  pytest --looponfail -n auto --dist=loadscope
+	  pytest --looponfail -n auto --dist=loadscope $(test_args)
 	@-docker stop karmen_pg_test
 	@-docker rm karmen_pg_test
 	@-docker stop karmen_redis_test

--- a/src/karmen_frontend/scripts/docker-start.sh
+++ b/src/karmen_frontend/scripts/docker-start.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 
-DIR=$(dirname $(realpath -s $0))
-cd $DIR
+cd `dirname $0`
 
 IS_CLOUD_INSTALL=`if [ ${CLOUD_MODE} == 1 ]; then echo 'true'; else echo 'false'; fi`
+
+echo "Starting frontend in IS_CLOUD_INSTALL=$IS_CLOUD_INSTALL"
 
 if [ "$ENV" = 'production' ]; then
   cat << EOF > "../build/env.js"


### PR DESCRIPTION
    - configuration moved to env files
    - docker-compose.release.yml changed to expose only the main port by default
    (connection to internal services can still be achieved by `docker-compose exec postgres: sh`
    - special configuration file `local.env` for installation specific
    settings
    - cleanup of docker-compose.yml to reuse configuration where possible rather than cut&paste
    - dedicated container for dbmigration moved to command, which is run before
    bacend_flask container starts up, to speed sturtup
    - dedicated container to set permission changed to properly set
    postgres container
    - dedicated container for setting permissions in backend container moved to the backend container startup script
    - now it is possible to run `docker-compose up --build --abort-on-container-exit` to exit the infrastructure if one of containers fails (not possible before due to excessive "run and die" containers)
    - removed double defaults in docker-start.sh (default value is already set in
    Dockerfile)
    - default ports for dev/testing services like dummymailserver changed to
    values used in dev/testing docker-compose.yml (it was used nowhere else)
