### PR TITLE
Fix organization switching when printer detail is opened

### DIFF
--- a/src/karmen_frontend/package.json
+++ b/src/karmen_frontend/package.json
@@ -52,6 +52,7 @@
     "eject": "react-scripts eject",
     "cypress": "cd cypress && npm run cypress",
     "lint": "eslint src --ext jsx,js",
+    "lint:fix": "eslint src --fix --ext jsx,js",
     "prettier": "prettier --check src/**/*.js cypress/**/*.js",
     "prettier:fix": "prettier --write src/**/*.js cypress/**/*.js",
     "start": "BROWSER=none REACT_APP_GIT_REV='@dev' react-scripts start",

--- a/src/karmen_frontend/src/actions/printers/reading.js
+++ b/src/karmen_frontend/src/actions/printers/reading.js
@@ -214,6 +214,12 @@ export const getWebcamSnapshot = createHttpAction(
   (orguuid, uuid, { dispatch, getState }) => {
     return denyWithNoOrganizationAccess(orguuid, getState, () => {
       let { printers } = getState();
+
+      // This can happen during organization switching and printer's detail opened. Just catch it silently.
+      if (printers.activeOrganizationUuid !== orguuid) {
+        return Promise.reject(new Error("organization mismatch"));
+      }
+
       const printer = printers.printers.find((p) => p.uuid === uuid);
 
       if (!printer || !printer.webcam || !printer.webcam.url) {
@@ -255,6 +261,9 @@ export const getWebcamSnapshot = createHttpAction(
         };
       });
     }).catch((err) => {
+      if (err.message === "organization mismatch") {
+        return;
+      }
       if (!(err instanceof HttpError)) {
         throw err;
       }

--- a/src/karmen_frontend/src/actions/printers/reading.js
+++ b/src/karmen_frontend/src/actions/printers/reading.js
@@ -1,7 +1,7 @@
 import { createHttpAction } from "../utils";
 import * as backend from "../../services/backend";
 import { retryIfUnauthorized, denyWithNoOrganizationAccess } from "../users-me";
-import { HttpError } from "../../errors";
+import { HttpError, OrganizationMismatchError } from "../../errors";
 
 const PRINTER_IDLE_POLL = Math.floor(Math.random() * (7000 + 1) + 11000);
 const PRINTER_RUNNING_POLL = Math.floor(Math.random() * (4000 + 1) + 5000);
@@ -217,7 +217,7 @@ export const getWebcamSnapshot = createHttpAction(
 
       // This can happen during organization switching and printer's detail opened. Just catch it silently.
       if (printers.activeOrganizationUuid !== orguuid) {
-        return Promise.reject(new Error("organization mismatch"));
+        return Promise.reject(new OrganizationMismatchError());
       }
 
       const printer = printers.printers.find((p) => p.uuid === uuid);
@@ -261,7 +261,7 @@ export const getWebcamSnapshot = createHttpAction(
         };
       });
     }).catch((err) => {
-      if (err.message === "organization mismatch") {
+      if (err instanceof OrganizationMismatchError) {
         return;
       }
       if (!(err instanceof HttpError)) {

--- a/src/karmen_frontend/src/errors.js
+++ b/src/karmen_frontend/src/errors.js
@@ -14,3 +14,10 @@ export class OfflineError extends Error {
 }
 
 export class UnauthorizedError extends Error {}
+
+export class OrganizationMismatchError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "OrganizationMismatchError";
+  }
+}


### PR DESCRIPTION
Checks if organization still matches, if not skip webcam snapshot.