### PR TITLE
removed support for dashboard.cypress.io

### DIFF
--- a/src/karmen_frontend/package.json
+++ b/src/karmen_frontend/package.json
@@ -57,7 +57,7 @@
     "start": "BROWSER=none REACT_APP_GIT_REV='@dev' react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jest-environment-jsdom-sixteen",
-    "test:cypress": "cd cypress && npm run test:cypress -- --record --key 0cf3da2a-6418-4f98-b923-3cb222a59cff --parallel"
+    "test:cypress": "cd cypress && npm run test:cypress"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.10.1",


### PR DESCRIPTION
The limit of 500 tests were depleted in half of business day. We need to
deal with limits before we can merge it to master