### PR TITLE
Ignore deprecation warning in itsdangerous

### DIFF
--- a/src/karmen_backend/pytest.ini
+++ b/src/karmen_backend/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 filterwarnings =
     ignore:The 'warn' method is deprecated, use 'warning' instead:DeprecationWarning
+    ignore:Importing 'itsdangerous.json' is deprecated and will be removed in 2.1. Use Python's 'json' module instead.


### PR DESCRIPTION
itsdangerous has it's JSON class (used by Flask) deprecated and throws warnings. Because of this, every time you run backend tests, your console gets flooded with  **1702** warnings, making it impossible to scroll to failed tests. 

After inspecting Flask repo, I find out that Flask already fixed this, but it's not released yet. In the meantime, while waiting for this fix to be released, it's fine to ignore this warning. 