### PR TITLE
Better error handling with stream.

### DIFF
--- a/src/karmen_frontend/src/actions/printers/reading.js
+++ b/src/karmen_frontend/src/actions/printers/reading.js
@@ -1,7 +1,12 @@
 import { createHttpAction } from "../utils";
 import * as backend from "../../services/backend";
 import { retryIfUnauthorized, denyWithNoOrganizationAccess } from "../users-me";
-import { HttpError, OrganizationMismatchError } from "../../errors";
+import {
+  HttpError,
+  OrganizationMismatchError,
+  StreamUnavailableError,
+  FailedToFetchDataError,
+} from "../../errors";
 
 const PRINTER_IDLE_POLL = Math.floor(Math.random() * (7000 + 1) + 11000);
 const PRINTER_RUNNING_POLL = Math.floor(Math.random() * (4000 + 1) + 5000);
@@ -232,47 +237,65 @@ export const getWebcamSnapshot = createHttpAction(
       return retryIfUnauthorized(
         backend.getWebcamSnapshot,
         dispatch
-      )(printer.webcam.url)
-        .then((r) => {
-          let { webcams } = getState();
-          if (webcams.queue && webcams.queue[uuid]) {
-            const timeoutData = webcams.queue[uuid];
+      )(printer.webcam.url).then((r) => {
+        let { webcams } = getState();
+        if (webcams.queue && webcams.queue[uuid]) {
+          const timeoutData = webcams.queue[uuid];
 
-            if (timeoutData.interval > 0) {
-              const timeout = setTimeout(
-                () => dispatch(getWebcamSnapshot(orguuid, uuid)),
-                timeoutData.interval
-              );
+          if (timeoutData.interval > 0) {
+            const timeout = setTimeout(
+              () => dispatch(getWebcamSnapshot(orguuid, uuid)),
+              timeoutData.interval
+            );
 
-              dispatch({
-                type: "WEBCAMS_TIMEOUT_SET",
-                payload: {
-                  uuid,
-                  interval: timeoutData.interval,
-                  timeout,
-                },
-              });
-            }
+            dispatch({
+              type: "WEBCAMS_TIMEOUT_SET",
+              payload: {
+                uuid,
+                interval: timeoutData.interval,
+                timeout,
+              },
+            });
           }
-          return {
-            organizationUuid: orguuid,
-            uuid,
-            status: r.status,
-            ...r.data,
-            successCodes: [200],
-          };
-        })
-        .catch((r) => {
-          return {
-            organizationUuid: orguuid,
-            uuid,
-            status: 404,
-          };
-        });
+        }
+        return {
+          organizationUuid: orguuid,
+          uuid,
+          status: r.status,
+          ...r.data,
+          successCodes: [200],
+        };
+      });
     }).catch((err) => {
+      if (err instanceof StreamUnavailableError) {
+        //we got 404 from server - this means Karmen has no url to get stream from printer
+        //so we just return 404 to snapshots array so stream renderer can tell this to the user
+        //and we stop trying to get images
+        return {
+          organizationUuid: orguuid,
+          uuid,
+          status: 404,
+        };
+      }
       if (err instanceof OrganizationMismatchError) {
         return;
       }
+
+      if (err instanceof FailedToFetchDataError) {
+        //For various reasons (changing wifi, browser suspended tab on mobile, bad connection, etc), single request can fail to fetch.
+        //This causes the stream to freeze, throws generic error toaster and user has to reload the page.
+        //If we catch this case and dispatch another request after few second, we are very likely to overcome
+        //this gap and go on like nothing happen
+        //We don't have to worry about offline states - if heartbeat fails, all requests get's killed
+        setTimeout(() => dispatch(getWebcamSnapshot(orguuid, uuid)), 5000);
+        //We also return 502 to snapshots array, so the stream renderer components displays "retrying" message.
+        return {
+          organizationUuid: orguuid,
+          uuid,
+          status: 502,
+        };
+      }
+
       if (!(err instanceof HttpError)) {
         throw err;
       }

--- a/src/karmen_frontend/src/components/printers/__tests__/webcam-stream.js
+++ b/src/karmen_frontend/src/components/printers/__tests__/webcam-stream.js
@@ -52,21 +52,13 @@ const renderWebcamStreamRenderer = (printer, imageData = null) => {
   );
 };
 
-const expectStreamUnavailable = (queryByAltText, getByText) => {
-  expect(
-    queryByAltText("Last screenshot from undefined")
-  ).not.toBeInTheDocument();
-  expect(getByText("Stream unavailable")).toBeInTheDocument();
-};
-
 it("WebcamStreamRenderer: is available", async () => {
   const printer = createPrinter(true);
-  const { queryByText, getByAltText } = renderWebcamStreamRenderer(
-    printer,
-    "image-data"
-  );
+  const { queryByText } = renderWebcamStreamRenderer(printer, [
+    "data:image/jpg,image-data",
+    202,
+  ]);
 
-  expect(getByAltText("Last screenshot from undefined")).toBeInTheDocument();
   expect(queryByText("Stream unavailable")).not.toBeInTheDocument();
 });
 
@@ -74,24 +66,29 @@ it("WebcamStreamRenderer: is not available due to absence of image", async () =>
   const printer = createPrinter(true);
   const { getByText, queryByAltText } = renderWebcamStreamRenderer(printer);
 
-  expectStreamUnavailable(queryByAltText, getByText);
+  expect(
+    queryByAltText("Last screenshot from undefined")
+  ).not.toBeInTheDocument();
+  expect(getByText("Starting stream")).toBeInTheDocument();
 });
 
 it("WebcamStreamRenderer: is not available due to client is disconnected", async () => {
   const printer = createPrinter(false);
-  const { getByText, queryByAltText } = renderWebcamStreamRenderer(
-    printer,
-    "image-data"
-  );
-
-  expectStreamUnavailable(queryByAltText, getByText);
+  const { getByText, queryByAltText } = renderWebcamStreamRenderer(printer, [
+    undefined,
+    404,
+  ]);
+  expect(
+    queryByAltText("Last screenshot from undefined")
+  ).not.toBeInTheDocument();
+  expect(getByText("Stream unavailable")).toBeInTheDocument();
 });
 
 it("WebcamStream", async () => {
   const printer = createPrinter(false);
   const store = mockStore({
     webcams: {
-      images: { [printerUuid]: "data-url image" },
+      images: { [printerUuid]: ["data:image/jpg,image-data", 202] },
       queue: { [printerUuid]: { interval: 200, timeout: 20 } },
     },
   });

--- a/src/karmen_frontend/src/components/printers/webcam-stream.js
+++ b/src/karmen_frontend/src/components/printers/webcam-stream.js
@@ -50,7 +50,6 @@ export const WebcamStreamRenderer = ({
   rotate90,
   allowFullscreen,
   printer,
-  setWebcamRefreshInterval,
 }) => {
   let klass = [];
   if (flipHorizontal) {

--- a/src/karmen_frontend/src/components/printers/webcam-stream.js
+++ b/src/karmen_frontend/src/components/printers/webcam-stream.js
@@ -64,8 +64,7 @@ export const WebcamStreamRenderer = ({
     klass.push("rotate-90");
   }
 
-  let image,
-    status_code = undefined;
+  let image, status_code;
   if (imageResponse) {
     image = imageResponse[0];
     status_code = imageResponse[1];

--- a/src/karmen_frontend/src/errors.js
+++ b/src/karmen_frontend/src/errors.js
@@ -28,3 +28,16 @@ export class OrganizationMismatchError extends Error {
     this.name = "OrganizationMismatchError";
   }
 }
+
+export class StreamUnavailableError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "StreamUnavailableError";
+  }
+}
+export class FailedToFetchDataError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "FailedToFetchDataError";
+  }
+}

--- a/src/karmen_frontend/src/reducers/webcams.js
+++ b/src/karmen_frontend/src/reducers/webcams.js
@@ -34,18 +34,21 @@ export default (
           },
         }),
       });
-    case "WEBCAMS_GET_SNAPSHOT_SUCCEEDED":
+    case "WEBCAMS_GET_SNAPSHOT_ENDED":
       if (action.payload.organizationUuid !== activeOrganizationUuid) {
         return state;
       }
       let newImage = action.payload;
-      if (!newImage || newImage.status !== 200) {
+      if (!newImage) {
         state.images = Object.assign({}, state.images, {
-          [newImage.uuid]: undefined,
+          [newImage.uuid]: [undefined, action.payload.status],
         });
       } else {
         state.images = Object.assign({}, state.images, {
-          [newImage.uuid]: `${newImage.prefix}${newImage.data}`,
+          [newImage.uuid]: [
+            `${newImage.prefix}${newImage.data}`,
+            action.payload.status,
+          ],
         });
       }
       return state;

--- a/src/karmen_frontend/src/services/backend/printers/reading.js
+++ b/src/karmen_frontend/src/services/backend/printers/reading.js
@@ -57,29 +57,18 @@ export const getWebcamSnapshot = (snapshotUrl) => {
     headers: headers,
   })
     .then((response) => {
-      if (response.status === 200) {
-        let contentType = response.headers.get("content-type");
-        return response.arrayBuffer().then((buffer) => ({
-          status: 200,
-          successCodes: [200, 202],
-          data: {
-            prefix: `data:${contentType ? contentType : "image/jpeg"};base64,`,
-            data: arrayBufferToBase64(buffer),
-          },
-        }));
+      let contentType = response.headers.get("content-type");
+      if (response.status === 404) {
+        return Promise.reject(new HttpError("Stream not available"));
       }
-      if (response.status !== 202) {
-        console.error(
-          `Couldn't get webcam snapshot from ${fullSnapshotURL}: ${response.status}`
-        );
-        return Promise.reject(
-          new HttpError(
-            response,
-            `Cannot get webcam snapshot: ${response.status}`
-          )
-        );
-      }
-      return { status: response.status, successCodes: [200, 202] };
+      return response.arrayBuffer().then((buffer) => ({
+        status: response.status, // response.status,
+        successCodes: [200, 202],
+        data: {
+          prefix: `data:${contentType ? contentType : "image/jpeg"};base64,`,
+          data: arrayBufferToBase64(buffer),
+        },
+      }));
     })
     .catch((err) => {
       // Only log down errors originating outside of this handler.

--- a/src/karmen_frontend/src/services/backend/printers/reading.js
+++ b/src/karmen_frontend/src/services/backend/printers/reading.js
@@ -1,4 +1,8 @@
-import { HttpError } from "../../../errors";
+import {
+  HttpError,
+  StreamUnavailableError,
+  FailedToFetchDataError,
+} from "../../../errors";
 import { getJsonPostHeaders, performRequest } from "../utils";
 
 const BASE_URL = window.env.BACKEND_BASE;
@@ -58,22 +62,41 @@ export const getWebcamSnapshot = (snapshotUrl) => {
   })
     .then((response) => {
       let contentType = response.headers.get("content-type");
-      if (response.status === 404) {
-        return Promise.reject(new HttpError("Stream not available"));
+      //OK responses, let's show stream to the user
+      if ([200, 202].includes(response.status)) {
+        return response.arrayBuffer().then((buffer) => ({
+          status: response.status, // response.status,
+          successCodes: [200, 202],
+          data: {
+            prefix: `data:${contentType ? contentType : "image/jpeg"};base64,`,
+            data: arrayBufferToBase64(buffer),
+          },
+        }));
       }
-      return response.arrayBuffer().then((buffer) => ({
-        status: response.status, // response.status,
-        successCodes: [200, 202],
-        data: {
-          prefix: `data:${contentType ? contentType : "image/jpeg"};base64,`,
-          data: arrayBufferToBase64(buffer),
-        },
-      }));
+      //No stream available - no reason to keep trying
+      if (response.status === 404) {
+        return Promise.reject(new StreamUnavailableError());
+      }
+      //These status codes failed, but they were expected.
+      //When FailedToFetchDataError is thrown, parent function waits few seconds and then tries to fetch image again
+      if ([502, 504].includes(response.status)) {
+        return Promise.reject(new FailedToFetchDataError());
+      }
+
+      return Promise.reject(
+        new HttpError("Could not get snapshot " + response.status)
+      );
     })
     .catch((err) => {
       // Only log down errors originating outside of this handler.
       if (!(err instanceof HttpError)) {
         console.error(`Cannot get webcam snapshot: ${err}`);
+      }
+      if (
+        err instanceof TypeError &&
+        err.toString() === "TypeError: Failed to fetch"
+      ) {
+        return Promise.reject(new FailedToFetchDataError());
       }
       throw err;
     });


### PR DESCRIPTION
Initially, user is shown "starting stream" message. If there is some fail, stream is replaced with "error, retrying"-like message. If no stream is available (404), we tell it to the user, and stop asking for more pictures